### PR TITLE
Write watchdog reset cause to RAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,18 @@
 #
 # Authors:
 #   Jan Kiszka <jan.kiszka@siemens.com>
+#   Li Huaqian <huaqian.li@siemens.com>
 
 CROSS_COMPILE = arm-linux-gnueabihf-
 CC = gcc
 
 RTI_MODULE = 1
+PON_REASON_BASE_ADDR = 0xA2200000
 
 CFLAGS = -mcpu=cortex-r5 -DRTI_MODULE=$(RTI_MODULE)
+ifneq ($(PON_REASON_BASE_ADDR), -1)
+CFLAGS += -DPON_REASON_BASE_ADDR=$(PON_REASON_BASE_ADDR)
+endif
 LDFLAGS = -nostdlib -N -Wl,-strip-all -Wl,--build-id -static -Wl,--nmagic
 
 k3-rti-wdt.fw: lscript.lds firmware.o

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ call `make`.
 By default, the firmware supports RTI1 as this is known to work fine on the
 AM65x. To build it for RTI0, compile it via `make RTI_MODULE=0`.
 
+By default, the firmware also supports to save watchdog reset cause to RAM at
+0xA2200000. To build it for other RAM locations, compile it via
+`make PON_REASON_BASE_ADDR=<addr>`. To build it for disabling the saving watchdog
+reset cause, compile it via `make PON_REASON_BASE_ADDR=-1`.
+
 
 Usage
 -----

--- a/firmware.S
+++ b/firmware.S
@@ -1,9 +1,10 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (c) Siemens AG, 2020-2021
+ * Copyright (c) Siemens AG, 2020-2023
  *
  * Authors:
  *   Jan Kiszka <jan.kiszka@siemens.com>
+ *   Li Huaqian <huaqian.li@siemens.com>
  */
 
 #define VIM_VEC_INT			0x40f82000
@@ -11,6 +12,15 @@
 
 #define SEC_PROXY_STATUS		0x2a380000
 #define SEC_PROXY_MSG_DATA		0x2a480004
+
+#if defined(PON_REASON_BASE_ADDR)
+#define PON_REASON_SOF_ADDR     	PON_REASON_BASE_ADDR
+#define PON_REASON_MAGIC_ADDR   	(4 + PON_REASON_BASE_ADDR)
+#define PON_REASON_EOF_ADDR     	(8 + PON_REASON_BASE_ADDR)
+#define PON_REASON_SOF_NUM      	0xBBBBCCCC
+#define PON_REASON_MAGIC_NUM    	0xDDDDDDDD
+#define PON_REASON_EOF_NUM      	0xCCCCBBBB
+#endif
 
 #define HOST_R5_SEC_0			4
 #define PROC_R5_0			1
@@ -157,6 +167,22 @@ rx_wt:	ldr	r4, [r2]
  * Reset system via TISCI
  */
 sys_reset:
+#if defined(PON_REASON_BASE_ADDR)
+	/* Record the PON REASON in memory */
+	ldr r2, =PON_REASON_SOF_ADDR
+	ldr r3, =PON_REASON_SOF_NUM
+	str r3, [r2]
+
+	ldr r2, =PON_REASON_MAGIC_ADDR
+	ldr r3, =PON_REASON_MAGIC_NUM
+	str r3, [r2]
+
+	ldr r2, =PON_REASON_EOF_ADDR
+	ldr r3, =PON_REASON_EOF_NUM
+	str r3, [r2]
+	dsb
+#endif
+
 	adr	r0, sys_reset_msg
 	adr	r1, sys_reset_msg_end
 	bl	send_msg


### PR DESCRIPTION
As mentioned in issues#1, it would be good to record the watchdog restart cause, so that the OS can know what happened.

This patch writes some specific info to memory(RAM) which will be reserved and protected in bootloader and OS.